### PR TITLE
Add cmake script + tests + github actions support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+on:
+  - push
+  - pull_request
+jobs:
+  build_test:
+    name: "Build and test libproperties using CMake"
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+        build_shared_libs: ["ON", "OFF"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: "Checkout repo"
+        uses: actions/checkout@v2
+      - name: "Setup java"
+        uses: actions/setup-java@v1
+        with:
+          java-version: 13
+      - name: "Configure/build/install libproperties"
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DBUILD_SHARED_LIBS=${{ matrix.build_shared_libs }}
+          cmake --build .
+          ctest -VV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,6 @@ project(libproperties VERSION ${MY_VERSION} LANGUAGES C)
 #   Define GNU standard installation directories
 include(GNUInstallDirs)
 
-#   We need -fsigned-char for ARM compiler
-set(CMAKE_C_FLAGS "-fsigned-char ${CMAKE_C_FLAGS}")
-
 #   Define the target
 add_library(properties buf.c properties.c)
 set_target_properties(properties PROPERTIES
@@ -29,6 +26,11 @@ target_include_directories(properties PUBLIC
 if(NOT BUILD_SHARED_LIBS)
     target_compile_definitions(properties PUBLIC LIBPROPERTIES_STATIC)
 endif()
+target_compile_options(properties PRIVATE
+    $<$<NOT:$<STREQUAL:$<C_COMPILER_ID>,MSVC>>:
+        #   We need -fsigned-char for ARM compiler
+        -fsigned-char
+    >)
 
 #   Install the library + header + cmake config file
 option(LIBPROPERTIES_INSTALL "Install libproperties" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,14 +16,19 @@ set(CMAKE_C_FLAGS "-fsigned-char ${CMAKE_C_FLAGS}")
 #   Define the target
 add_library(properties buf.c properties.c)
 set_target_properties(properties PROPERTIES
-    VERSION     ${PROJECT_VERSION}
-    SOVERSION   ${PROJECT_VERSION_MAJOR}
-    EXPORT_NAME libproperties
+    VERSION             ${PROJECT_VERSION}
+    SOVERSION           ${PROJECT_VERSION_MAJOR}
+    EXPORT_NAME         libproperties
+    DEFINE_SYMBOL       LIBPROPERTIES_EXPORT
+    C_VISIBILITY_PRESET hidden
 )
 target_include_directories(properties PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
+if(NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(properties PUBLIC LIBPROPERTIES_STATIC)
+endif()
 
 #   Install the library + header + cmake config file
 option(LIBPROPERTIES_INSTALL "Install libproperties" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,14 +7,69 @@ string(STRIP "${MY_VERSION}" MY_VERSION)
 #   Define the project
 project(libproperties VERSION ${MY_VERSION} LANGUAGES C)
 
-#   Specify the output dir of the shared library
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+#   Define GNU standard installation directories
+include(GNUInstallDirs)
 
 #   We need -fsigned-char for ARM compiler
 set(CMAKE_C_FLAGS "-fsigned-char ${CMAKE_C_FLAGS}")
 
 #   Define the target
-add_library(properties SHARED buf.c properties.c)
-set_target_properties(properties PROPERTIES VERSION     ${CMAKE_PROJECT_VERSION})
-set_target_properties(properties PROPERTIES SOVERSION   ${CMAKE_PROJECT_VERSION_MAJOR} )
-target_include_directories(properties PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+add_library(properties buf.c properties.c)
+set_target_properties(properties PROPERTIES
+    VERSION     ${PROJECT_VERSION}
+    SOVERSION   ${PROJECT_VERSION_MAJOR}
+    EXPORT_NAME libproperties
+)
+target_include_directories(properties PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+#   Install the library + header + cmake config file
+option(LIBPROPERTIES_INSTALL "Install libproperties" ON)
+if(LIBPROPERTIES_INSTALL)
+    install(TARGETS properties EXPORT properties
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    )
+    install(FILES properties.h
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    )
+    install(EXPORT properties NAMESPACE "libproperties::"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECTNAME}"
+        FILE "libproperties-config.cmake"
+    )
+endif()
+
+#   Build + add the test target
+option(LIBPROPERTIES_TEST "Build the libproperties tests" ON)
+if(LIBPROPERTIES_TEST)
+    find_package(Java REQUIRED COMPONENTS Runtime Development)
+    include(UseJava)
+
+    add_jar(libproperties_test_jar test/Main.java
+        OUTPUT_NAME libproperties_test
+        ENTRY_POINT Main
+    )
+
+    add_executable(libproperties_test properties_test.c)
+    target_link_libraries(libproperties_test PRIVATE properties)
+
+    enable_testing()
+
+    function(libproproperties_add_test_compare NAME PROPERTIES)
+        add_test(NAME ${NAME}
+            COMMAND "${CMAKE_COMMAND}"
+                "-DJava_JAVA_EXECUTABLE=${Java_JAVA_EXECUTABLE}"
+                "-DLIBPROPERTIES_JAR=${CMAKE_CURRENT_BINARY_DIR}/libproperties_test.jar"
+                "-DLIBPROPERTIES_TEST=$<TARGET_FILE:libproperties_test>"
+                "-DPROPERTIES=${PROPERTIES}"
+                -P "${CMAKE_CURRENT_SOURCE_DIR}/test/compare_java.cmake"
+        )
+        set_tests_properties(${NAME} PROPERTIES TIMEOUT 5)
+    endfunction()
+
+    libproproperties_add_test_compare(libproperties_test_1 "${CMAKE_CURRENT_SOURCE_DIR}/test/1.properties")
+    libproproperties_add_test_compare(libproperties_test_2 "${CMAKE_CURRENT_SOURCE_DIR}/test/2.properties")
+endif()

--- a/properties.h
+++ b/properties.h
@@ -1,6 +1,22 @@
 #ifndef __properties_H_
 #define __properties_H_
 
+#ifdef LIBPROPERTIES_EXPORT
+#ifdef _WIN32
+#define LIBPROPERTIES_EXTERN __declspec(dllexport)
+#else
+#define LIBPROPERTIES_EXTERN __attribute__((visibility("default")))
+#endif
+#elif !defined(LIBPROPERTIES_STATIC)
+#ifdef _WIN32
+#define LIBPROPERTIES_EXTERN __declspec(dllimport)
+#else
+#define LIBPROPERTIES_EXTERN
+#endif
+#else
+#define LIBPROPERTIES_EXTERN
+#endif
+
 #ifdef __cplusplus
 #define EXTERN extern "C" {
 #endif
@@ -37,11 +53,11 @@ typedef int (*PROPERTYS_HANDLER)(void* context, char* key, int key_len, char* va
 //  \param  handler         The callback function, to notify the user that the parser find a new key-value pair.
 //
 //  \return If there is no error, return 0, otherwise return -1.
-int properties_parse(void* source_context, PROPERTIES_SOURCE_READ source_read, void* handler_context, PROPERTYS_HANDLER handler);
+LIBPROPERTIES_EXTERN int properties_parse(void* source_context, PROPERTIES_SOURCE_READ source_read, void* handler_context, PROPERTYS_HANDLER handler);
 
 //! The function `properties_source_file_read` is the default implement for read from a file.
 //  \notice The `file` Should be a `FILE*`.
-int properties_source_file_read(void* file, char* buf, int* size);
+LIBPROPERTIES_EXTERN int properties_source_file_read(void* file, char* buf, int* size);
 
 //! The function `properties_source_string_read` is the default implement for read from a string.
 //  To use this function, you need fill the `struct properties_source_string_t`, and give it is as
@@ -50,7 +66,7 @@ struct properties_source_string_t {
     char* str; ///<    The start address of the input string.
     char* end; ///<    The end address of the input string.
 };
-int properties_source_string_read(void* source, char* buf, int* size);
+LIBPROPERTIES_EXTERN int properties_source_string_read(void* source, char* buf, int* size);
 
 #ifdef __cplusplus
 }

--- a/properties.h
+++ b/properties.h
@@ -1,13 +1,9 @@
 #ifndef __properties_H_
 #define __properties_H_
 
-#ifndef EXTERN
 #ifdef __cplusplus
-#define EXTERN extern "C"
-#else
-#define EXTERN
+#define EXTERN extern "C" {
 #endif
-#endif //EXTERN
 
 //! This function will be called when the parser need more text.
 //
@@ -41,11 +37,11 @@ typedef int (*PROPERTYS_HANDLER)(void* context, char* key, int key_len, char* va
 //  \param  handler         The callback function, to notify the user that the parser find a new key-value pair.
 //
 //  \return If there is no error, return 0, otherwise return -1.
-EXTERN int properties_parse(void* source_context, PROPERTIES_SOURCE_READ source_read, void* handler_context, PROPERTYS_HANDLER handler);
+int properties_parse(void* source_context, PROPERTIES_SOURCE_READ source_read, void* handler_context, PROPERTYS_HANDLER handler);
 
 //! The function `properties_source_file_read` is the default implement for read from a file.
 //  \notice The `file` Should be a `FILE*`.
-EXTERN int properties_source_file_read(void* file, char* buf, int* size);
+int properties_source_file_read(void* file, char* buf, int* size);
 
 //! The function `properties_source_string_read` is the default implement for read from a string.
 //  To use this function, you need fill the `struct properties_source_string_t`, and give it is as
@@ -54,6 +50,10 @@ struct properties_source_string_t {
     char* str; ///<    The start address of the input string.
     char* end; ///<    The end address of the input string.
 };
-EXTERN int properties_source_string_read(void* source, char* buf, int* size);
+int properties_source_string_read(void* source, char* buf, int* size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif //__properties_H_

--- a/test.sh
+++ b/test.sh
@@ -67,7 +67,7 @@ function    generate_expect_files()
 
 
 
-function    run_teatcases()
+function    run_testcases()
 {
     local exe_tool=${TESTDIR}/libproperties_test
     if [ "x${OS}" == "xWindows_NT" ]; then
@@ -154,7 +154,7 @@ function main()
     echo    "----"
     echo    "Run testcases ..."
     echo    ""
-    run_teatcases
+    run_testcases
     RESULT=$?
     echo    ""
     if [ $RESULT -ne 0 ]; then

--- a/test/compare_java.cmake
+++ b/test/compare_java.cmake
@@ -1,0 +1,29 @@
+# run java -jar libproperties_test.jar <input_jar>
+execute_process(
+    COMMAND "${Java_JAVA_EXECUTABLE}" -jar "${LIBPROPERTIES_JAR}" "${PROPERTIES}"
+    OUTPUT_VARIABLE java_stdout
+    RESULT_VARIABLE java_result
+)
+
+if(java_result)
+    message(FATAL_ERROR "Running '${Java_JAVA_EXECUTABLE} -jar ${LIBPROPRTIES_JAR} ${PROPERTIES} failed with ${java_result}")
+endif()
+
+# run libproperties_test <input_jar>
+execute_process(
+    COMMAND "${LIBPROPERTIES_TEST}" "${PROPERTIES}"
+    OUTPUT_VARIABLE libproperties_stdout
+    RESULT_VARIABLE libproperties_result
+)
+
+if(libproperties_result)
+    message(FATAL_ERROR "Running '${LIBPROPERTIES_TEST} ${PROPERTIES}' failed with ${libproperties_result}")
+endif()
+
+# compare their output
+
+if(java_stdout STREQUAL libproperties_stdout)
+    message(STATUS "java and libproperties output match!")
+else()
+    message(FATAL_ERROR "java and libproperties produced different outputs!")
+endif()


### PR DESCRIPTION
Hello,

this pr improves the cmake script by:
- allowing static + shared (including allowing dll's on windows)
- adds installation though cmake
- adds testing using ctest: it compares the output of the test and the java executable
- adds CI by making use of github actions

The tests currently fail due to a timeout and assertion error.
See https://github.com/madebr/libproperties/actions/runs/419190631 for a test run.